### PR TITLE
Move update in rtm1_0_70 to release branch

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,72 +1,84 @@
 # Contributor Code of Conduct
-
-## Related Code of Conduct 
-
-Participant Code of Conduct
-https://www2.fin.ucar.edu/ethics/participant-code-conduct
+_The Contributor Code of Conduct is for participants in our software projects and community._
 
 ## Our Pledge
-We, as contributors and maintainers (participants), of River Transport Model (RTM) pledge to make participation in our software project and community a safe, productive, welcoming and inclusive experience for everyone. All participants are required to abide by this Code of Conduct. This includes respectful treatment of everyone regardless of age, body size, disability, ethnicity, gender identity or expression, level of experience, nationality, political affiliation, veteran status, pregnancy, genetic information, physical appearance, race, religion, or sexual orientation, as well as any other characteristic protected under applicable US federal or state law.
+We, as contributors, creators, stewards, and maintainers (participants), of River Transport Model (RTM) pledge to make participation in our software, system or hardware project and community a safe, productive, welcoming and inclusive experience for everyone.
+All participants are required to abide by this Code of Conduct.
+This includes respectful treatment of everyone regardless of age, body size, disability, ethnicity, gender identity or expression, level of experience, nationality, political affiliation, veteran status, pregnancy, genetic information, physical appearance, race, religion, or sexual orientation, as well as any other characteristic protected under applicable US federal or state law.
 
 ## Our Standards
 Examples of behaviors that contribute to a positive environment include:
-* Using welcoming and inclusive language
-* Respectful when offering and gracefully accepting constructive criticism
-* Acknowledging the contributions of others 
-* Focusing on what is best for the community
-* Showing empathy towards other community members
-* Treating everyone with respect and consideration, valuing a diversity of views and opinions
-* Communicating openly with respect for others, critiquing ideas rather than individuals
+
+* All participants are treated with respect and consideration, valuing a diversity of views and opinions
+* Be considerate, respectful, and collaborative
+* Communicate openly with respect for others, critiquing ideas rather than individuals and gracefully accepting criticism
+* Acknowledging the contributions of others
+* Avoid personal attacks directed toward other participants
+* Be mindful of your surroundings and of your fellow participants 
+* Alert UCAR staff and suppliers/vendors if you notice a dangerous situation or someone in distress
+* Respect the rules and policies of the project and venue
 
 Examples of unacceptable behavior include, but are not limited to:
+
 * Harassment, intimidation, or discrimination in any form
-* Personal attacks directed toward other participants
+* Physical, verbal, or written abuse by anyone to anyone, including repeated use of pronouns other than those requested
 * Unwelcome sexual attention or advances
-* Inappropriate, negative, derogatory comments and/or attacks on personal beliefs
+* Personal attacks directed at other guests, members, participants, etc.
 * Publishing others' private information, such as a physical or electronic address, without explicit permission
-* Refusing to use the pronouns that someone requests
 * Alarming, intimidating, threatening, or hostile comments or conduct
-* Physical or verbal abuse by anyone to anyone, including but not limited to a participant, member of the public, guest, member of any institution or sponsor
-* Comments related to characteristics given in the pledge at the top
 * Inappropriate use of nudity and/or sexual images 
-* Threatening or stalking other participants
+* Threatening or stalking anyone, including a participant
 * Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Scope
-
-This Code of Conduct applies to all spaces managed by the Project whether it be online or face-to-face. This includes project code, code repository, associated web pages, documentation, mailing lists, project websites and wiki pages, issue tracker, meetings, telecons, events, project social media accounts, and any other forums created by the project team which the community uses for communication. In addition, violations of this Code of Conduct outside these spaces may affect a person's ability to participate within them. Representation of a project may be further defined and clarified by project maintainers.
+This Code of Conduct applies to all spaces managed by the Project whether they be physical, online or face-to-face.
+This includes project code, code repository, associated web pages, documentation, mailing lists, project websites and wiki pages, issue tracker, meetings, telecons, events, project social media accounts, and any other forums created by the project team which the community uses for communication.
+In addition, violations of this Code of Conduct outside these spaces may affect a person's ability to participate within them.
+Representation of a project may be further defined and clarified by project maintainers.
 
 ## Community Responsibilities
+Everyone in the community is empowered to respond to people who are showing unacceptable behavior.
+They can talk to them privately or publicly.
+Anyone requested to stop unacceptable behavior is expected to comply immediately.
+If the behavior continues concerns may be brought to the project administrators or to any other party listed in the [Reporting](#reporting) section below.
 
-Everyone in the community is empowered to respond to people who are showing unacceptable behavior. They can talk to them privately or publicly. Anyone requested to stop unacceptable behavior is expected to comply immediately. If the behavior continues concerns may be brought to the project administrators or to any other party listed in the Reporting section below.
-Project Administrator Responsibilities
-Project Administrators are responsible for clarifying the standards of acceptable behavior and are encouraged to model appropriate behavior and provide support when people in the community point out inappropriate behavior. Project administrator(s) are normally the ones that would be tasked to carry out the actions in the Consequences section below.
- 
-Project Administrators are also expected to keep this Code of Conduct updated with the main one housed at UCAR as listed below in the Attribution section.
+## Project Administrator Responsibilities
+Project administrators are responsible for clarifying the standards of acceptable behavior and are encouraged to model appropriate behavior and provide support when people in the community point out inappropriate behavior.
+Project administrator(s) are normally the ones that would be tasked to carry out the actions in the [Consequences](#consequences) section below.
+
+Project administrators are also expected to keep this Code of Conduct updated with the main one housed at UCAR, as listed below in the [Attribution](#attribution) section.
 
 ## Reporting
-Instances of unacceptable behavior can be brought to the attention of the project administrator(s) who may take any action as outlined in the Consequences section below. However, making a report to a project administrator is not considered an ‘official report’ to UCAR.
- 
-Instances of unacceptable behavior may also be reported directly to UCAR via UCAR’s Harassment Reporting and Complaint Procedure at https://www2.fin.ucar.edu/procedures/hr/harassment-reporting-and-complaint-procedure, or anonymously through UCAR’s EthicsPoint Hotline at https://www2.fin.ucar.edu/ethics/anonymous-reporting. 
-Complaints received by UCAR will be handled pursuant to the procedures outlined in UCAR’s Harassment Reporting and Complaint Procedure. Complaints to UCAR will be held as confidential as practicable under the circumstances, and retaliation against a person who initiates a complaint or an inquiry about inappropriate behavior will not be tolerated.
- 
-Any Contributor can use these reporting methods even if they are not directly affiliated with UCAR. The Frequently Asked Questions (FAQ) page for reporting is here: https://www2.fin.ucar.edu/procedures/hr/reporting-faqs.
+Instances of unacceptable behavior can be brought to the attention of the project administrator(s) who may take any action as outlined in the [Consequences](#consequences) section below.
+However, making a report to a project administrator is not considered an 'official report' to UCAR. 
+
+Instances of unacceptable behavior may also be reported directly to UCAR pursuant to [UCAR's Harassment Reporting and Complaint Procedure](https://www2.fin.ucar.edu/procedures/hr/harassment-reporting-and-complaint-procedure), or anonymously through [UCAR's EthicsPoint Hotline](https://www2.fin.ucar.edu/ethics/anonymous-reporting).
+
+Complaints received by UCAR will be handled pursuant to the procedures outlined in UCAR's Harassment Reporting and Complaint Procedure.
+Complaints to UCAR will be held as confidential as practicable under the circumstances, and retaliation against a person who initiates a complaint or an inquiry about inappropriate behavior will not be tolerated.
+
+Any Contributor can use these reporting methods even if they are not directly affiliated with UCAR.
+The Frequently Asked Questions (FAQ) page for reporting is [here](https://www2.fin.ucar.edu/procedures/hr/reporting-faqs).
 
 ## Consequences
-Upon receipt of a complaint, the project administrator(s) may take any action deemed necessary and appropriate under the circumstances. Such action can include things such as: removing, editing, or rejecting comments, commits, code, wiki edits, email, issues, and other contributions that are not aligned to this Code of Conduct, or banning temporarily or permanently any contributor for other behaviors that are deemed inappropriate, threatening, offensive, or harmful. Project Administrators also have the right to report violations to UCAR HR and/or UCAR’s Office of Diversity, Equity and Inclusion (ODEI) as well as a participant’s home institution and/or law enforcement. In the event an incident is reported to UCAR, UCAR will follow its Harassment Reporting and Complaint Procedure. 
+Upon receipt of a complaint, the project administrator(s) may take any action deemed necessary and appropriate under the circumstances.
+Such action can include things such as: removing, editing, or rejecting comments, commits, code, wiki edits, email, issues, and other contributions that are not aligned to this Code of Conduct, or banning temporarily or permanently any contributor for other behaviors that are deemed inappropriate, threatening, offensive, or harmful.
+Project administrators also have the right to report violations to UCAR HR and/or UCAR's Office of Diversity, Equity and Inclusion (ODEI), as well as a participant's home institution and/or law enforcement.
+In the event an incident is reported to UCAR, UCAR will follow its Harassment Reporting and Complaint Procedure.
 
 ## Process for Changes
-All UCAR managed projects are required to adopt this Contributor Code of Conduct. Adoption is assumed even if not expressly stated in the repository. Projects should fill in sections where prompted with project-specific information, including, project name, email addresses, adoption date, etc. There is one section below marked “optional” that may not apply to a given project. 
+All UCAR managed projects are required to adopt this Contributor Code of Conduct.
+Adoption is assumed even if not expressly stated in the repository.
+Projects should fill in sections where prompted with project-specific information, including, project name and adoption date.
 
-Projects that adopt this Code of Conduct need to stay up to date with UCAR's Contributor Code of Conduct, linked with a DOI in the "Attribution" section below. Projects can make limited substantive changes to the Code of Conduct, however, the changes must be limited in scope and may not contradict the UCAR Contributor Code of Conduct.
+Projects that adopt this Code of Conduct need to stay up to date with UCAR's Contributor Code of Conduct, linked with a DOI in the [Attribution](#attribution) section below.
+Projects can make limited substantive changes to the Code of Conduct, however, the changes must be limited in scope and may not contradict the UCAR Contributor Code of Conduct.
 
 ## Attribution
-This Code of Conduct was originally adapted from the Contributor Covenant, version 1.4, available at [Contributor-Covenant](http://contributor-covenant.org/version/1/4) We then aligned it with the UCAR Participant Code of Conduct, which also borrows from the American Geophysical Union (AGU) Code of Conduct. The UCAR Participant Code of Conduct applies to both UCAR employees as well as participants in activities run by UCAR. We modified the “scope” section with the django project description, and we added “Publication Ethics” from the NGEET/FATES project. The original version of this for all software projects that have strong management from UCAR or UCAR staff is available on the UCAR website at _**`[Enter DOI link name]`**_ (the date that it was adopted by this project was Dec/5/2018) When responding to complaints UCAR HR and ODEI will do so based on the latest published version. Therefore, any project-specific changes should follow the Process for Changes section above.
-
-## Publication Ethics
-We aim to create an open development environment where developers can be confident that all members of the community are publishing any research on the project in an ethical manner. In particular, writing code is a form of intellectual contribution, and one should expect that all such intellectual contributions are respected and given credit in any resulting published work. To support the community and avoid issues of misconduct related to the above principle, please respect the following rules:
- 
-* Document the version of the code used in any publication, preferably by either using a release tag (existing or newly created) if possible, or a commit hash if not.
-* Do not use code from anywhere other than the central project’s development repository main development branch without discussing with the author(s) of the modified code your intentions for using the code and receiving their permission to do so.
-* When using project features that have recently been integrated into the central Project development repository, be mindful of the contributions of others and, where the novel features qualitatively affect the results, involve the author(s) of these features in any resulting manuscripts. Be particularly aware of the concerns of early career researchers, and ensure they have sufficient time to lead publications using their developments.
-* When discussing results arising from older project features that have been described in the literature or releases, accurately cite the publications describing those features or releases.
+This Code of Conduct was originally adapted from the [Contributor Covenant](http://contributor-covenant.org/version/1/4), version 1.4.
+We then aligned it with the UCAR Participant Code of Conduct, which also borrows from the American Geophysical Union (AGU) Code of Conduct.
+The UCAR Participant Code of Conduct applies to both UCAR employees as well as participants in activities run by UCAR.
+The original version of this for all software projects that have strong management from UCAR or UCAR staff is available on the UCAR website at https://doi.org/10.5065/6w2c-a132.
+The date that it was adopted by this project was Dec/5th/2018
+When responding to complaints, UCAR HR and ODEI will do so based on the latest published version.
+Therefore, any project-specific changes should follow the [Process for Changes](#process-for-changes) section above.

--- a/cime_config/testdefs/testlist_rtm.xml
+++ b/cime_config/testdefs/testlist_rtm.xml
@@ -5,7 +5,7 @@
     <machines>
       <machine name="cheyenne" compiler="intel" category="rtm"></machine>
       <machine name="cheyenne" compiler="gnu" category="rtm"></machine>
-      <machine name="hobart" compiler="nag" category="rtm"></machine>
+      <machine name="izumi" compiler="nag" category="rtm"></machine>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -16,7 +16,7 @@
     <machines>
       <machine name="cheyenne" compiler="intel" category="rtm"></machine>
       <machine name="cheyenne" compiler="gnu" category="rtm"></machine>
-      <machine name="hobart" compiler="nag" category="rtm"></machine>
+      <machine name="izumi" compiler="nag" category="rtm"></machine>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>
@@ -27,7 +27,7 @@
     <machines>
       <machine name="cheyenne" compiler="intel" category="rtm"></machine>
       <machine name="cheyenne" compiler="gnu" category="rtm"></machine>
-      <machine name="hobart" compiler="nag" category="rtm"></machine>
+      <machine name="izumi" compiler="nag" category="rtm"></machine>
     </machines>
     <options>
       <option name="wallclock">00:20:00</option>

--- a/docs/ChangeLog
+++ b/docs/ChangeLog
@@ -1,4 +1,17 @@
 ===============================================================
+Tag name:  rtm1_0_70
+Originator(s): erik
+Date: Nov 08, 2019
+One-line Summary: Rename uses of SHR_KIND_CL to CL for a cime update
+
+    Change wallclock time in tests and change hobart for izumi
+
+    Add Code of Conduct.
+    
+    Have all instances of SHR_KIND_CL use CL that is renamed from SHR_KIND_CL.
+    This is important for a recent cime update.
+
+===============================================================
 Tag name:  rtm1_0_69
 Originator(s): erik
 Date: Jun 03, 2019

--- a/docs/release-cesm2.0.ChangeLog
+++ b/docs/release-cesm2.0.ChangeLog
@@ -1,4 +1,33 @@
 ===============================================================
+Tag name:  release-cesm2.0.04
+Originator(s): erik
+Date: Jan 13, 2020
+One-line Summary: Bring in updates to rtm1_0_70
+
+Update release branch to rtm1_0_70. This updates
+the code of conduct to the standard UCAR version.
+It also moves testing from hobart to izumi. And it
+changes instances of SHR_KIND_ to lowercase.
+
+RTM Master Tag This Corresponds To: rtm1_0_69 (with changes)
+
+Software Changes since last release: release-cesm2.0.03
+  * Remove mosart from some files
+
+Science Changes since last release: release-cesm2.0.00
+  * None
+
+Changes to User Interface since: release-cesm2.0.03
+  * None
+
+Pull Requests that document the changes (include PR ids):
+
+Testing:
+   rtm -- cheyenne_intel ?
+   rtm -- cheyenne_gnu   ?
+   rtm -- izumi_nag      ?
+
+===============================================================
 Tag name:  release-cesm2.0.03
 Originator(s): erik
 Date: Aug 01, 2019

--- a/docs/release-cesm2.0.ChangeLog
+++ b/docs/release-cesm2.0.ChangeLog
@@ -1,7 +1,7 @@
 ===============================================================
 Tag name:  release-cesm2.0.04
 Originator(s): erik
-Date: Jan 13, 2020
+Date: Jan 14, 2020
 One-line Summary: Bring in updates to rtm1_0_70
 
 Update release branch to rtm1_0_70. This updates
@@ -9,7 +9,7 @@ the code of conduct to the standard UCAR version.
 It also moves testing from hobart to izumi. And it
 changes instances of SHR_KIND_ to lowercase.
 
-RTM Master Tag This Corresponds To: rtm1_0_69 (with changes)
+RTM Master Tag This Corresponds To: rtm1_0_70 (with changes)
 
 Software Changes since last release: release-cesm2.0.03
   * Remove mosart from some files
@@ -21,11 +21,12 @@ Changes to User Interface since: release-cesm2.0.03
   * None
 
 Pull Requests that document the changes (include PR ids):
+  #19 -- Move update in rtm1_0_70 to release branch
 
 Testing:
-   rtm -- cheyenne_intel ?
-   rtm -- cheyenne_gnu   ?
-   rtm -- izumi_nag      ?
+   rtm -- cheyenne_intel PASS
+   rtm -- cheyenne_gnu   PASS
+   rtm -- izumi_nag      PASS
 
 ===============================================================
 Tag name:  release-cesm2.0.03

--- a/src/cpl/rof_comp_mct.F90
+++ b/src/cpl/rof_comp_mct.F90
@@ -7,7 +7,7 @@ module rof_comp_mct
 ! in MCT (Model Coupling Toolkit) format and converting it to use by RTM
 
   use seq_flds_mod
-  use shr_kind_mod     , only : r8 => shr_kind_r8
+  use shr_kind_mod     , only : r8 => shr_kind_r8, CL => shr_kind_cl
   use shr_file_mod     , only : shr_file_setLogUnit, shr_file_setLogLevel, &
                                 shr_file_getLogUnit, shr_file_getLogLevel, &
                                 shr_file_getUnit, shr_file_setIO
@@ -95,14 +95,14 @@ contains
     integer :: lbnum                                 ! input to memory diagnostic
     integer :: shrlogunit,shrloglev                  ! old values for log unit and log level
     integer :: begr, endr
-    character(len=SHR_KIND_CL) :: caseid             ! case identifier name
-    character(len=SHR_KIND_CL) :: ctitle             ! case description title
-    character(len=SHR_KIND_CL) :: starttype          ! start-type (startup, continue, branch, hybrid)
-    character(len=SHR_KIND_CL) :: calendar           ! calendar type name
-    character(len=SHR_KIND_CL) :: hostname           ! hostname of machine running on
-    character(len=SHR_KIND_CL) :: version            ! Model version
-    character(len=SHR_KIND_CL) :: username           ! user running the model
-    character(len=SHR_KIND_CL) :: model_doi_url      ! Web address for model Digital Object Identifier (DOI)
+    character(len=CL) :: caseid                      ! case identifier name
+    character(len=CL) :: ctitle                      ! case description title
+    character(len=CL) :: starttype                   ! start-type (startup, continue, branch, hybrid)
+    character(len=CL) :: calendar                    ! calendar type name
+    character(len=CL) :: hostname                    ! hostname of machine running on
+    character(len=CL) :: version                     ! Model version
+    character(len=CL) :: username                    ! user running the model
+    character(len=CL) :: model_doi_url               ! Web address for model Digital Object Identifier (DOI)
     character(len=32), parameter :: sub = 'rof_init_mct'
     character(len=*),  parameter :: format = "('("//trim(sub)//") :',A)"
     !---------------------------------------------------------------------------

--- a/src/riverroute/RtmVar.F90
+++ b/src/riverroute/RtmVar.F90
@@ -1,6 +1,6 @@
 module RtmVar
 
-  use shr_kind_mod , only : r8 => shr_kind_r8, SHR_KIND_CL
+  use shr_kind_mod , only : r8 => shr_kind_r8, CL => SHR_KIND_CL
   use shr_const_mod, only : SHR_CONST_CDAY,SHR_CONST_REARTH
   use shr_sys_mod  , only : shr_sys_abort
   use RtmSpmd      , only : masterproc
@@ -18,8 +18,8 @@ module RtmVar
   real(r8) :: re = SHR_CONST_REARTH*0.001_r8                   ! radius of earth (km)
 
   ! Run control variables
-  character(len=SHR_KIND_CL), public :: caseid  = ' '          ! case id
-  character(len=SHR_KIND_CL), public :: ctitle  = ' '          ! case title
+  character(len=CL), public :: caseid  = ' '                   ! case id
+  character(len=CL), public :: ctitle  = ' '                   ! case title
   integer, public, parameter :: nsrStartup  = 0                ! Startup from initial conditions
   integer, public, parameter :: nsrContinue = 1                ! Continue from restart files
   integer, public, parameter :: nsrBranch   = 2                ! Branch from restart files
@@ -27,12 +27,12 @@ module RtmVar
   logical, public :: brnch_retain_casename = .false.           ! true => allow case name to remain the same for branch run
                                                                ! by default this is not allowed
   logical, public :: noland = .false.                          ! true => no valid land points -- do NOT run
-  character(len=SHR_KIND_CL), public :: hostname = ' '         ! Hostname of machine running on
-  character(len=SHR_KIND_CL), public :: username = ' '         ! username of user running program
-  character(len=SHR_KIND_CL), public :: version  = " "         ! version of program
-  character(len=SHR_KIND_CL), public :: conventions = "CF-1.0" ! dataset conventions
-  character(len=SHR_KIND_CL), public :: source   = "Community Land Model CLM4.0" ! description of this source
-  character(len=SHR_KIND_CL), public :: model_doi_url          ! Web address of the Digital Object Identifier (DOI) for this model version
+  character(len=CL), public :: hostname = ' '                  ! Hostname of machine running on
+  character(len=CL), public :: username = ' '                  ! username of user running program
+  character(len=CL), public :: version  = " "                  ! version of program
+  character(len=CL), public :: conventions = "CF-1.0"          ! dataset conventions
+  character(len=CL), public :: source   = "River Transport Model RTM1.0" ! description of this source
+  character(len=CL), public :: model_doi_url                   ! Web address of the Digital Object Identifier (DOI) for this model version
 
   ! Unit Numbers
   integer, public :: iulog = 6        ! "stdout" log file unit number, default is 6
@@ -43,20 +43,20 @@ module RtmVar
   character(len=16), public :: inst_suffix
 
   ! Rtm control variables
-  character(len=SHR_KIND_CL), public :: nrevsn_rtm   = ' '   ! restart data file name for branch run
-  character(len=SHR_KIND_CL), public :: finidat_rtm  = ' '   ! initial conditions file name
-  character(len=SHR_KIND_CL), public :: frivinp_rtm  = ' '   ! RTM input data file name
-  logical,            public :: ice_runoff = .true.  ! true => runoff is split into liquid and ice, 
-                                                     ! otherwise just liquid
-  logical,            public :: rtm_active    = .true.   ! true => rtm on
-  logical,            public :: flood_active  = .false.  ! true => flood on
-  logical,            public :: effvel_active = .false.  ! true => calculate eff. velocity from rdirc file
+  character(len=CL), public :: nrevsn_rtm   = ' '       ! restart data file name for branch run
+  character(len=CL), public :: finidat_rtm  = ' '       ! initial conditions file name
+  character(len=CL), public :: frivinp_rtm  = ' '       ! RTM input data file name
+  logical,           public :: ice_runoff = .true.      ! true => runoff is split into liquid and ice, 
+                                                        ! otherwise just liquid
+  logical,           public :: rtm_active    = .true.   ! true => rtm on
+  logical,           public :: flood_active  = .false.  ! true => flood on
+  logical,           public :: effvel_active = .false.  ! true => calculate eff. velocity from rdirc file
  
   ! Rtm grid size
   integer :: rtmlon = 1 ! number of rtm longitudes (initialize)
   integer :: rtmlat = 1 ! number of rtm latitudes  (initialize)
 
-  character(len=SHR_KIND_CL), public :: rpntfil = 'rpointer.rof' ! file name for local restart pointer file
+  character(len=CL), public :: rpntfil = 'rpointer.rof' ! file name for local restart pointer file
 
   logical, private :: RtmVar_isset = .false.
 
@@ -73,14 +73,14 @@ contains
     !  Set input control variables.
     !
     ! !ARGUMENTS:
-    character(len=SHR_KIND_CL), optional, intent(IN) :: caseid_in        ! case id
-    character(len=SHR_KIND_CL), optional, intent(IN) :: ctitle_in        ! case title
-    integer,                    optional, intent(IN) :: nsrest_in        ! 0: initial run. 1: restart: 3: branch
-    character(len=SHR_KIND_CL), optional, intent(IN) :: version_in       ! model version
-    character(len=SHR_KIND_CL), optional, intent(IN) :: hostname_in      ! hostname running on
-    character(len=SHR_KIND_CL), optional, intent(IN) :: username_in      ! username running job
-    character(len=SHR_KIND_CL), optional, intent(IN) :: model_doi_url_in ! web address of Digital Object Identifier (DOI) for model version
-    logical,            optional, intent(IN) :: brnch_retain_casename_in ! true => allow case name to
+    character(len=CL), optional, intent(IN) :: caseid_in                ! case id
+    character(len=CL), optional, intent(IN) :: ctitle_in                ! case title
+    integer          , optional, intent(IN) :: nsrest_in                ! 0: initial run. 1: restart: 3: branch
+    character(len=CL), optional, intent(IN) :: version_in               ! model version
+    character(len=CL), optional, intent(IN) :: hostname_in              ! hostname running on
+    character(len=CL), optional, intent(IN) :: username_in              ! username running job
+    character(len=CL), optional, intent(IN) :: model_doi_url_in         ! web address of Digital Object Identifier (DOI) for model version
+    logical          , optional, intent(IN) :: brnch_retain_casename_in ! true => allow case name to
     !-----------------------------------------------------------------------
 
     if ( RtmVar_isset )then


### PR DESCRIPTION
Update release branch to rtm1_0_70. This updates
the code of conduct to the standard UCAR version.
It also moves testing from hobart to izumi. And it
changes instances of SHR_KIND_ to lowercase.